### PR TITLE
Argparse

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,10 +1,32 @@
 def main():
     from kmap_solver import KMap
+    from argparse import ArgumentParser
 
-    num_of_variables = int(input("Enter the number of variables (Between 0 to 26): "))
-    bit_limit = ((2**num_of_variables)-1)
-    minterms = set(map(int, input(f"Enter the minterms (Between 0 to {bit_limit}): ").split()))
-    dont_cares = set(map(int, input(f"Enter the dont cares (Between 0 to {bit_limit}): ").split()))
+    parser = ArgumentParser(description="find prime implicants, essential prime implicants, and all minimum sum of products forms.")
+
+    parser.add_argument('num_of_variables', metavar='v', type=int,
+            choices=range(27), help='Number of variables in the kmap')
+
+    args = parser.parse_known_args()[0]
+
+    bit_limit = ((2**args.num_of_variables)-1)
+
+    parser.add_argument('minterms', metavar='m', type=int,
+            nargs='+', choices=range(bit_limit+1), help='Minterms')
+
+    # don't cares are optional
+    parser.add_argument('--dont_cares', metavar='d', nargs='*',
+            type=int, help="Don't cares", choices=range(bit_limit+1))
+
+    args = parser.parse_args();
+    num_of_variables = args.num_of_variables
+    minterms = set(args.minterms)
+    dont_cares = set(args.dont_cares) if args.dont_cares is not None else set()
+
+    intersection = minterms & dont_cares
+
+    if(intersection):
+        raise ValueError(f"minterms and dont_cares are not unique {intersection}")
 
     my_kmap = KMap(num_of_variables, minterms, dont_cares)
 

--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ def main():
 
     intersection = minterms & dont_cares
     if(intersection):
-        raise ValueError(f"minterms and dont_cares are not unique {intersection}")
+        raise ValueError(f"minterms and dont_cares are not disjoint {intersection}")
 
 
     my_kmap = KMap(num_of_variables, minterms, dont_cares)

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ def main():
                 nargs='+', choices=range(bit_limit+1), help='Minterms')
 
         # don't cares are optional
-        parser.add_argument('--dont-cares', metavar='d', nargs='*',
+        parser.add_argument('-d', '--dont-cares', metavar='d', nargs='*',
                 type=int, help="Don't cares", choices=range(bit_limit+1))
 
         args = parser.parse_args();

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ def main():
                 nargs='+', choices=range(bit_limit+1), help='Minterms')
 
         # don't cares are optional
-        parser.add_argument('--dont_cares', metavar='d', nargs='*',
+        parser.add_argument('--dont-cares', metavar='d', nargs='*',
                 type=int, help="Don't cares", choices=range(bit_limit+1))
 
         args = parser.parse_args();

--- a/main.py
+++ b/main.py
@@ -1,32 +1,45 @@
 def main():
     from kmap_solver import KMap
-    from argparse import ArgumentParser
+    from argparse import ArgumentParser, BooleanOptionalAction
 
     parser = ArgumentParser(description="find prime implicants, essential prime implicants, and all minimum sum of products forms.")
 
-    parser.add_argument('num_of_variables', metavar='v', type=int,
-            choices=range(27), help='Number of variables in the kmap')
+    parser.add_argument('-i', '--interactive', action=BooleanOptionalAction,
+            default=False)
 
     args = parser.parse_known_args()[0]
 
-    bit_limit = ((2**args.num_of_variables)-1)
+    # maybe split this if block into its own function? I'm
+    # reluctent to to change the structure of main though
+    if not args.interactive:
+        parser.add_argument('num_of_variables', metavar='v', type=int,
+                choices=range(27), help='Number of variables in the kmap')
 
-    parser.add_argument('minterms', metavar='m', type=int,
-            nargs='+', choices=range(bit_limit+1), help='Minterms')
+        args = parser.parse_known_args()[0]
+        bit_limit = ((2**args.num_of_variables)-1)
 
-    # don't cares are optional
-    parser.add_argument('--dont_cares', metavar='d', nargs='*',
-            type=int, help="Don't cares", choices=range(bit_limit+1))
+        parser.add_argument('minterms', metavar='m', type=int,
+                nargs='+', choices=range(bit_limit+1), help='Minterms')
 
-    args = parser.parse_args();
-    num_of_variables = args.num_of_variables
-    minterms = set(args.minterms)
-    dont_cares = set(args.dont_cares) if args.dont_cares is not None else set()
+        # don't cares are optional
+        parser.add_argument('--dont_cares', metavar='d', nargs='*',
+                type=int, help="Don't cares", choices=range(bit_limit+1))
+
+        args = parser.parse_args();
+        num_of_variables = args.num_of_variables
+        minterms = set(args.minterms)
+        dont_cares = set(args.dont_cares) if args.dont_cares is not None else set()
+
+    else:
+        num_of_variables = int(input("Enter the number of variables (Between 0 to 26): "))
+        bit_limit = ((2**num_of_variables)-1)
+        minterms = set(map(int, input(f"Enter the minterms (Between 0 to {bit_limit}): ").split()))
+        dont_cares = set(map(int, input(f"Enter the dont cares (Between 0 to {bit_limit}): ").split()))
 
     intersection = minterms & dont_cares
-
     if(intersection):
         raise ValueError(f"minterms and dont_cares are not unique {intersection}")
+
 
     my_kmap = KMap(num_of_variables, minterms, dont_cares)
 


### PR DESCRIPTION
Allow for non-interactive use. The old behavior can still be accessed through the `-i` flag.